### PR TITLE
Change github.com/MentorEmbedded to github.com/SourceryTools

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -26,7 +26,7 @@ NVPTX_RUN_LDFLAGS += $(DL_LIBS)
 #NVPTX_RUN_CPPFLAGS += -DNVPTX_RUN_LINK_LIBCUDA
 #NVPTX_RUN_LDFLAGS += -L[CUDA]/lib64/stubs
 #NVPTX_RUN_LDFLAGS += -lcuda
-# See <https://github.com/MentorEmbedded/nvptx-tools/pull/21> 'Work around "libnvidia-fatbinaryloader.so needed by libcuda.so" linking issue'.
+# See <https://github.com/SourceryTools/nvptx-tools/pull/21> 'Work around "libnvidia-fatbinaryloader.so needed by libcuda.so" linking issue'.
 #NVPTX_RUN_LDFLAGS += -Wl,--allow-shlib-undefined
 
 AR = @AR@

--- a/README
+++ b/README
@@ -85,4 +85,4 @@ the nvptx-tools without a CUDA installation.
 Report Issues
 -------------
 
-Report issues to <https://github.com/MentorEmbedded/nvptx-tools/issues>.
+Report issues to <https://github.com/SourceryTools/nvptx-tools/issues>.

--- a/configure
+++ b/configure
@@ -2150,7 +2150,7 @@ if test "${with_bugurl+set}" = set; then :
 	   ;;
      esac
 else
-  BUGURL="https://github.com/MentorEmbedded/nvptx-tools/issues"
+  BUGURL="https://github.com/SourceryTools/nvptx-tools/issues"
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 AC_INIT([nvptx-tools])
 ACX_PKGVERSION([nvptx-tools])
-ACX_BUGURL([https://github.com/MentorEmbedded/nvptx-tools/issues])
+ACX_BUGURL([https://github.com/SourceryTools/nvptx-tools/issues])
 AC_CONFIG_SRCDIR([nvptx-as.cc])
 AC_CONFIG_MACRO_DIRS([config])
 

--- a/nvptx-as.cc
+++ b/nvptx-as.cc
@@ -882,7 +882,7 @@ process (FILE *in, FILE *out, int *verify, const char *inname)
   const char *input = read_file (in);
 
   /* As expected by GCC, handle an empty input file specially.  See
-     <https://github.com/MentorEmbedded/nvptx-tools/pull/26> "[nvptx-as] Allow
+     <https://github.com/SourceryTools/nvptx-tools/pull/26> "[nvptx-as] Allow
      empty input file" for reference.  */
   if (*input == '\0')
     {

--- a/nvptx-ld.cc
+++ b/nvptx-ld.cc
@@ -445,7 +445,7 @@ This program has absolutely no warranty.\n",
 	  exit (0);
 	case OPT_hash_style:
 	  /* Ignore '--hash-style'; see
-	     <https://github.com/MentorEmbedded/nvptx-tools/pull/44>
+	     <https://github.com/SourceryTools/nvptx-tools/pull/44>
 	     "Handle --hash-style argument in nvptx-ld".  */
 	  break;
 	default:
@@ -511,7 +511,7 @@ This program has absolutely no warranty.\n",
       if (archive::is_archive (f))
 	{
 	  /* (Pre-existing problem of) non-standard Unix 'ld' semantics; see
-	     <https://github.com/MentorEmbedded/nvptx-tools/issues/41>
+	     <https://github.com/SourceryTools/nvptx-tools/issues/41>
 	     "ld: non-standard handling of options which refer to files".  */
 	  libraries.push_back (name);
 

--- a/test/ar/help-1-xfail-1.test
+++ b/test/ar/help-1-xfail-1.test
@@ -1,6 +1,6 @@
 Variant of 'help-1.test'.
 XFAIL: *
-See <https://github.com/MentorEmbedded/nvptx-tools/issues/4> "nvptx-none-ar and nvptx-none-ranlib".
+See <https://github.com/SourceryTools/nvptx-tools/issues/4> "nvptx-none-ar and nvptx-none-ranlib".
 
 RUN: %target_ar_cmd --help > %t.stdout 2> %t.stderr
 RUN: < %t.stdout head -n 1 | grep -qe '^Usage: nvptx-none-ar '

--- a/test/ar/version-1-xfail-1.test
+++ b/test/ar/version-1-xfail-1.test
@@ -1,6 +1,6 @@
 Variant of 'version-1.test'.
 XFAIL: *
-See <https://github.com/MentorEmbedded/nvptx-tools/issues/4> "nvptx-none-ar and nvptx-none-ranlib".
+See <https://github.com/SourceryTools/nvptx-tools/issues/4> "nvptx-none-ar and nvptx-none-ranlib".
 
 RUN: %target_ar_cmd --version > %t.stdout 2> %t.stderr
 RUN: < %t.stdout head -n 1 | grep -qe '^nvptx-none-ar '

--- a/test/as/debug/directive-file-1.test
+++ b/test/as/debug/directive-file-1.test
@@ -1,4 +1,4 @@
-<https://github.com/MentorEmbedded/nvptx-tools/issues/20> 'nvptx-as reorders ".file" directives'
+<https://github.com/SourceryTools/nvptx-tools/issues/20> 'nvptx-as reorders ".file" directives'
 
 In the file produced by GCC, expect 'nvptx-none-as' to reorder '.file' directives:
 RUN: %target_as_cmd --no-verify %S/directive-file-1.s -o %t

--- a/test/as/garbage-1.test
+++ b/test/as/garbage-1.test
@@ -1,4 +1,4 @@
-<https://github.com/MentorEmbedded/nvptx-tools/issues/28> "nvptx-as should diagnose unexpected input instead of silently ignoring it"
+<https://github.com/SourceryTools/nvptx-tools/issues/28> "nvptx-as should diagnose unexpected input instead of silently ignoring it"
 
 Document current buggy behavior.
 

--- a/test/as/order-1.test
+++ b/test/as/order-1.test
@@ -1,4 +1,4 @@
-<https://github.com/MentorEmbedded/nvptx-tools/pull/29> "Ensure :VAR_MAP and :FUNC_MAP are output in order"
+<https://github.com/SourceryTools/nvptx-tools/pull/29> "Ensure :VAR_MAP and :FUNC_MAP are output in order"
 <https://gcc.gnu.org/PR100059> "[OpenMP] wrong code with 'declare target link' and a scalar variable"
 
 RUN: %target_as_cmd --no-verify %S/order-1-x86_64-linux-gnu.s -o %t

--- a/test/ld/hash-style-1.test
+++ b/test/ld/hash-style-1.test
@@ -1,4 +1,4 @@
-<https://github.com/MentorEmbedded/nvptx-tools/pull/44> "Handle --hash-style argument in nvptx-ld".
+<https://github.com/SourceryTools/nvptx-tools/pull/44> "Handle --hash-style argument in nvptx-ld".
 
 
     option '--hash-style' requires an argument

--- a/test/ranlib/help-1-xfail-1.test
+++ b/test/ranlib/help-1-xfail-1.test
@@ -1,6 +1,6 @@
 Variant of 'help-1.test'.
 XFAIL: *
-See <https://github.com/MentorEmbedded/nvptx-tools/issues/4> "nvptx-none-ar and nvptx-none-ranlib".
+See <https://github.com/SourceryTools/nvptx-tools/issues/4> "nvptx-none-ar and nvptx-none-ranlib".
 
 RUN: %target_ranlib_cmd --help > %t.stdout 2> %t.stderr
 RUN: < %t.stdout head -n 1 | grep -qe '^Usage: nvptx-none-ranlib '

--- a/test/ranlib/version-1-xfail-1.test
+++ b/test/ranlib/version-1-xfail-1.test
@@ -1,6 +1,6 @@
 Variant of 'version-1.test'.
 XFAIL: *
-See <https://github.com/MentorEmbedded/nvptx-tools/issues/4> "nvptx-none-ar and nvptx-none-ranlib".
+See <https://github.com/SourceryTools/nvptx-tools/issues/4> "nvptx-none-ar and nvptx-none-ranlib".
 
 RUN: %target_ranlib_cmd --version > %t.stdout 2> %t.stderr
 RUN: < %t.stdout head -n 1 | grep -qe '^nvptx-none-ranlib '


### PR DESCRIPTION
This shows up when building via the BUGURL but also in the README.md

As the github URL has changed, it makes sense to update this, even if there is currently a redirect from the old to the new address.

@tschwinge